### PR TITLE
Update to reflect Testing

### DIFF
--- a/genesis-beta-tester.php
+++ b/genesis-beta-tester.php
@@ -6,7 +6,7 @@
  * Author: Nathan Rice
  * Author URI: http://www.nathanrice.net/
 
- * Version: 1.0.0
+ * Version: 1.0.1
 
  * Text Domain: genesis-beta-tester
  * Domain Path: /languages/

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "description": "Genesis Beta Tester lets you one-click update to the latest version of Genesis, even if it is still in beta.",
     "author": "StudioPress",
     "authoruri": "http://www.studiopress.com/",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "GPL-2.0+",
     "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "genesis-beta-tester"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: genesis, genesiswp, studiopress
 Requires at least: 3.9
 Tested up to: 5.2.2
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 
 This plugin lets you one-click update to the latest Genesis release, even if it's still in beta.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, wpmuguru
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: genesis, genesiswp, studiopress
 Requires at least: 3.9
-Tested up to: 4.9.8
+Tested up to: 5.2.2
 Stable tag: 1.0.0
 
 This plugin lets you one-click update to the latest Genesis release, even if it's still in beta.
@@ -29,6 +29,9 @@ Not just yet, but that feature is coming.
 If you activate the plugin and do not see the update notification, that likely means that there is no beta release currently available. However, if you know there is a beta update available, and still do not see the notification, try visiting the "Dashboard -> Updates" screen and look for the update there.
 
 == Changelog ==
+
+= 1.0.1 =
+* Test with latest WordPress version
 
 = 1.0.0 =
 * Conform to WordPress Development Standards for PHP


### PR DESCRIPTION
Update the `Tested up to` value and the changelog. This update will remove the `This plugin hasn’t been tested with the latest 3 major releases of WordPress` on wordpress.org.