### PR TITLE
[LOC-6737] ci: reinstate 'tested up to' deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  wp-svn: studiopress/wp-svn@0.1
+  wp-svn: studiopress/wp-svn@0.2
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
-# orbs:
-#   wp-svn: studiopress/wp-svn@0.1
+orbs:
+  wp-svn: studiopress/wp-svn@0.1
 
 jobs:
   test:
@@ -23,16 +23,16 @@ workflows:
   test-deploy:
     jobs:
       - test
-      # - approval-for-deploy-tested-up-to-bump:
-      #     type: approval
-      #     requires:
-      #       - test
-      #     filters:
-      #       tags:
-      #         ignore: /.*/
-      #       branches:
-      #         only: /^bump-tested-up-to.*/
-      # - wp-svn/deploy-tested-up-to-bump:
-      #     context: genesis-svn
-      #     requires:
-      #       - approval-for-deploy-tested-up-to-bump
+      - approval-for-deploy-tested-up-to-bump:
+          type: approval
+          requires:
+            - test
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: /^bump-tested-up-to.*/
+      - wp-svn/deploy-tested-up-to-bump:
+          context: genesis-svn
+          requires:
+            - approval-for-deploy-tested-up-to-bump


### PR DESCRIPTION
So we can deploy 'tested up to' updates to WP.org again by:

- Creating a branch named `bump-tested-up-to-[version]`
- Bumping 'tested up to' in the readme.
- Pushing to GitHub, approving the job in Circle, awaiting deployment.

https://wordpress.org/plugins/genesis-beta-tester should then reflect the 'tested up to' version after any required approvals for the deploy on WP.org.