### PR TITLE
[LOC-6737] chore: bump 'tested up to' to 6.9

### DIFF
--- a/genesis-beta-tester.php
+++ b/genesis-beta-tester.php
@@ -6,7 +6,7 @@
  * Author: Nathan Rice
  * Author URI: http://www.nathanrice.net/
 
- * Version: 1.0.2
+ * Version: 1.0.1
 
  * Text Domain: genesis-beta-tester
  * Domain Path: /languages/

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, wpmuguru
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: genesis, genesiswp, studiopress
 Requires at least: 3.9
-Tested up to: 6.6
+Tested up to: 6.9
 Stable tag: 1.0.2
 
 This plugin lets you one-click update to the latest Genesis release, even if it's still in beta.


### PR DESCRIPTION
Bumps tested-up-to version.

Circle should automatically deploy the change after approval.

Change should be reflected at https://wordpress.org/plugins/genesis-beta-tester.